### PR TITLE
Refactor GravshipExportMod into modular components

### DIFF
--- a/1.6/Source/GravshipExport/ExportPromptView.cs
+++ b/1.6/Source/GravshipExport/ExportPromptView.cs
@@ -1,0 +1,34 @@
+using UnityEngine;
+using Verse;
+
+namespace GravshipExport
+{
+    internal static class ExportPromptView
+    {
+        public static void Draw(Rect rect, ShipListItem target, ref string exportNameBuffer, System.Action onCreate, System.Action onCancel)
+        {
+            Widgets.DrawLightHighlight(rect);
+            var inner = rect.ContractedBy(8f);
+
+            Widgets.Label(new Rect(inner.x, inner.y, 180f, 24f), "Export as Mod:");
+            var inputRect = new Rect(inner.x + 188f, inner.y, inner.width - 368f, 24f);
+            exportNameBuffer = Widgets.TextField(inputRect, exportNameBuffer);
+
+            var createRect = new Rect(inner.xMax - 170f, inner.y, 80f, 24f);
+            var cancelRect = new Rect(inner.xMax - 85f, inner.y, 80f, 24f);
+
+            if (Widgets.ButtonText(createRect, "Create"))
+            {
+                if (target?.Ship != null && !string.IsNullOrWhiteSpace(exportNameBuffer))
+                {
+                    onCreate?.Invoke();
+                }
+            }
+
+            if (Widgets.ButtonText(cancelRect, "Cancel"))
+            {
+                onCancel?.Invoke();
+            }
+        }
+    }
+}

--- a/1.6/Source/GravshipExport/GravshipExportMod.cs
+++ b/1.6/Source/GravshipExport/GravshipExportMod.cs
@@ -1,49 +1,39 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
+using System;
 using System.Linq;
 using UnityEngine;
 using Verse;
 using RimWorld;
-using System.Security;
 
 namespace GravshipExport
 {
     public class GravshipExportMod : Mod
     {
-        private GravshipExportModSettings settings;
+        private const bool DebugLogs = false;
 
-        private Vector2 scrollPos;
+        private readonly ShipListView shipListView;
+        private readonly ShipExportController exportController;
+
+        private GravshipExportModSettings settings;
         private string searchText = string.Empty;
         private bool didInitialRefresh;
 
-        // Inline export prompt state
         private bool exportPromptOpen;
         private string exportNameBuffer = string.Empty;
-        private ShipItem exportTarget;
-
-        // Load/save logs only (no draw-loop spam)
-        private const bool DebugLogs = false;
-
-        private sealed class ShipItem
-        {
-            public ShipLayoutDefV2 Ship;
-            public bool IsExported;
-            public string ExportFilename; // e.g. "MyShip.xml"
-            public string SourceLabel;    // "User Created" | "Mod: X" | "Built-in"
-        }
+        private ShipListItem exportTarget;
 
         public GravshipExportMod(ModContentPack content) : base(content)
         {
             settings = GetSettings<GravshipExportModSettings>();
-            didInitialRefresh = false;
+            shipListView = new ShipListView(
+                () => ShipListBuilder.Build(Content),
+                new ShipRowDrawer());
+            exportController = new ShipExportController(Content, DebugLogs);
         }
 
         public override string SettingsCategory() => "Gravship Export";
 
         public override void DoSettingsWindowContents(Rect inRect)
         {
-            // Refresh once when opening settings
             if (!didInitialRefresh)
             {
                 if (DebugLogs) Log.Message("[GravshipExport/UI] Opening settings — performing initial refresh…");
@@ -64,26 +54,25 @@ namespace GravshipExport
                 TryRestoreLastUsedShip();
             }
 
-            // Header
             var headerRect = new Rect(inRect.x, inRect.y, inRect.width, 112f);
-            DrawHeader(headerRect);
+            ModHeaderView.Draw(headerRect, settings.lastUsedShip, ref searchText);
 
-            // Inline export prompt (shown just under the header)
             float promptHeight = exportPromptOpen ? 64f : 0f;
             if (exportPromptOpen)
             {
                 var promptRect = new Rect(inRect.x, headerRect.yMax + 4f, inRect.width, promptHeight);
-                DrawExportPrompt(promptRect);
+                ExportPromptView.Draw(
+                    promptRect,
+                    exportTarget,
+                    ref exportNameBuffer,
+                    HandleExportCreation,
+                    CloseExportPrompt);
             }
 
-            // List
             var listRect = new Rect(inRect.x, headerRect.yMax + 8f + promptHeight, inRect.width, inRect.height - headerRect.height - 8f - promptHeight);
             DrawShipList(listRect);
         }
 
-        // ──────────────────────────────────────────────
-        // Restore lastUsedShip by matching loaded ships
-        // ──────────────────────────────────────────────
         private void TryRestoreLastUsedShip()
         {
             if (settings.lastUsedShip == null)
@@ -118,462 +107,71 @@ namespace GravshipExport
             Log.Warning($"[GravshipExport/Restore] Could not find a ship with defName='{defName}'. Highlight may fail until reapplied.");
         }
 
-        // ──────────────────────────────────────────────
-        // Header with current ship + search
-        // ──────────────────────────────────────────────
-        private void DrawHeader(Rect rect)
-        {
-            Widgets.DrawMenuSection(rect);
-            var inner = rect.ContractedBy(8f);
-
-            string currentLabel = settings.lastUsedShip != null
-                ? settings.lastUsedShip.label
-                : "None";
-
-            Widgets.Label(new Rect(inner.x, inner.y, inner.width, 24f), $"Current ship: {currentLabel}");
-
-            var searchLabelRect = new Rect(inner.x, inner.y + 32f, 100f, 24f);
-            Widgets.Label(searchLabelRect, "Search:");
-            var searchRect = new Rect(searchLabelRect.xMax + 8f, searchLabelRect.y, inner.width - searchLabelRect.width - 8f, 24f);
-            searchText = Widgets.TextField(searchRect, searchText);
-        }
-
-        // ──────────────────────────────────────────────
-        // Inline export prompt UI
-        // ──────────────────────────────────────────────
-        private void DrawExportPrompt(Rect rect)
-        {
-            Widgets.DrawLightHighlight(rect);
-            var inner = rect.ContractedBy(8f);
-
-            Widgets.Label(new Rect(inner.x, inner.y, 180f, 24f), "Export as Mod:");
-            var inputRect = new Rect(inner.x + 180f + 8f, inner.y, inner.width - 180f - 8f - 180f, 24f);
-
-            exportNameBuffer = Widgets.TextField(inputRect, exportNameBuffer);
-
-            var createRect = new Rect(inner.xMax - 170f, inner.y, 80f, 24f);
-            var cancelRect = new Rect(inner.xMax - 85f, inner.y, 80f, 24f);
-
-            if (Widgets.ButtonText(createRect, "Create"))
-            {
-                if (exportTarget?.Ship != null && !string.IsNullOrWhiteSpace(exportNameBuffer))
-                {
-                    TryExportShipAsMod(exportTarget, exportNameBuffer);
-                }
-            }
-            if (Widgets.ButtonText(cancelRect, "Cancel"))
-            {
-                exportPromptOpen = false;
-                exportTarget = null;
-                exportNameBuffer = string.Empty;
-            }
-        }
-
-        // ──────────────────────────────────────────────
-        // Scrollable list of ships
-        // ──────────────────────────────────────────────
         private void DrawShipList(Rect outRect)
         {
-            var rows = BuildShipRows();
-            if (rows.Count == 0)
+            var callbacks = new ShipListCallbacks
             {
-                Widgets.Label(outRect, "No ships found.\n\n• Export a ship in-game\n• Load a mod with ShipLayoutDefV2.");
+                DeleteRequested = HandleDeleteRequest,
+                ApplyRequested = HandleApplyRequest,
+                ExportRequested = HandleExportRequest
+            };
+
+            string currentKey = ShipSelectionHelper.GetCurrentSelectionKey(settings, ShipManager.LoadedShips);
+            shipListView.Draw(outRect, searchText, currentKey, callbacks);
+        }
+
+        private void HandleDeleteRequest(ShipListItem item)
+        {
+            if (item == null || string.IsNullOrEmpty(item.ExportFilename))
                 return;
-            }
 
-            if (!string.IsNullOrEmpty(searchText))
-            {
-                string f = searchText.ToLowerInvariant();
-                rows = rows.Where(r =>
-                    (r.Ship.label?.ToLowerInvariant().Contains(f) ?? false) ||
-                    (r.Ship.defName?.ToLowerInvariant().Contains(f) ?? false) ||
-                    (r.IsExported && (r.ExportFilename?.ToLowerInvariant().Contains(f) ?? false))
-                ).ToList();
-            }
-
-            const float rowHeight = 42f;
-            const float rowPad = 4f;
-            const float deleteBtnWidth = 32f;
-            const float applyBtnWidth = 50f;
-            const float exportBtnWidth = 50f;
-            const float infoWidth = 300f;
-            const float sourceWidth = 200f;
-
-            const int labelMaxChars = 30;
-            const int sourceMaxChars = 30;
-            const int infoMaxChars = 40;
-
-            var viewRect = new Rect(0f, 0f, outRect.width - 16f, rows.Count * rowHeight);
-            Widgets.BeginScrollView(outRect, ref scrollPos, viewRect);
-
-            string currentKey = CurrentSelectionKey();
-
-            for (int i = 0; i < rows.Count; i++)
-            {
-                var item = rows[i];
-                var ship = item.Ship;
-                var rowRect = new Rect(0f, i * rowHeight, viewRect.width, rowHeight);
-
-                string rowKey = item.IsExported ? item.ExportFilename : ship.defName;
-                bool isCurrent = !string.IsNullOrEmpty(currentKey) &&
-                                 currentKey.Equals(rowKey, StringComparison.OrdinalIgnoreCase);
-
-                if (isCurrent)
-                    Widgets.DrawBoxSolid(rowRect, new Color(0f, 1f, 0f, 0.15f));
-                else if (i % 2 == 1)
-                    Widgets.DrawBoxSolid(rowRect, new Color(1f, 1f, 1f, 0.05f));
-
-                float curX = rowRect.x + rowPad;
-
-                // 🗑️ Delete icon button (only for user-created ships)
-                if (item.IsExported)
+            string label = item.Ship?.label ?? item.ExportFilename;
+            Find.WindowStack.Add(Dialog_MessageBox.CreateConfirmation(
+                $"Are you sure you want to delete '{label}'?\n\nThis cannot be undone.",
+                () =>
                 {
-                    var deleteRect = new Rect(curX, rowRect.y + rowPad, deleteBtnWidth, rowHeight - 2 * rowPad);
-                    if (Widgets.ButtonImage(deleteRect, TexButton.Delete))
-                    {
-                        string filename = item.ExportFilename;
-                        Find.WindowStack.Add(Dialog_MessageBox.CreateConfirmation(
-                            $"Are you sure you want to delete '{ship.label}'?\n\nThis cannot be undone.",
-                            () =>
-                            {
-                                TryDeleteShipFile(filename);
-                                ShipManager.Refresh();
-                            }));
-                    }
-                    curX += deleteBtnWidth + rowPad;
-                }
-                else
-                {
-                    curX += deleteBtnWidth + rowPad; // Keep layout aligned
-                }
-
-                float rightX = rowRect.xMax - rowPad;
-
-                var applyRect = new Rect(rightX - applyBtnWidth, rowRect.y + rowPad, applyBtnWidth, rowHeight - 2 * rowPad);
-                rightX -= applyBtnWidth + rowPad;
-
-                var exportRect = new Rect(rightX - exportBtnWidth, rowRect.y + rowPad, exportBtnWidth, rowHeight - 2 * rowPad);
-                rightX -= exportBtnWidth + rowPad;
-
-                var infoRect = new Rect(rightX - infoWidth, rowRect.y + rowPad, infoWidth, rowHeight - 2 * rowPad);
-                rightX -= infoWidth + rowPad;
-
-                var sourceRect = new Rect(rightX - sourceWidth, rowRect.y + rowPad, sourceWidth, rowHeight - 2 * rowPad);
-                rightX -= sourceWidth + rowPad;
-
-                var labelRect = new Rect(curX, rowRect.y + rowPad, rightX - curX, rowHeight - 2 * rowPad);
-
-                // Label
-                string fullLabel = ship.label ?? ship.defName ?? "Unnamed Ship";
-                string drawLabel = HardCut(fullLabel, labelMaxChars);
-                Widgets.Label(labelRect, drawLabel);
-                if (!string.Equals(fullLabel, drawLabel, StringComparison.Ordinal))
-                    TooltipHandler.TipRegion(labelRect, fullLabel);
-
-                // Source
-                string fullSource = item.SourceLabel ?? "";
-                string drawSource = HardCut(fullSource, sourceMaxChars);
-                GUI.color = new Color(0.7f, 0.7f, 0.7f, 1f);
-                Widgets.Label(sourceRect, drawSource);
-                GUI.color = Color.white;
-                if (!string.Equals(fullSource, drawSource, StringComparison.Ordinal))
-                    TooltipHandler.TipRegion(sourceRect, fullSource);
-
-                // Info
-                string fullInfo = GetShipInfo(ship);
-                string drawInfo = HardCut(fullInfo, infoMaxChars);
-                Widgets.Label(infoRect, drawInfo);
-                if (!string.Equals(fullInfo, drawInfo, StringComparison.Ordinal))
-                    TooltipHandler.TipRegion(infoRect, fullInfo);
-
-                // Export button
-                if (item.IsExported)
-                {
-                    if (Widgets.ButtonText(exportRect, "Export"))
-                    {
-                        exportTarget = item;
-                        exportNameBuffer = $"Gravship_{(ship.label ?? ship.defName ?? "NewShip")}";
-                        exportPromptOpen = true;
-                    }
-                }
-
-                // Active / Apply
-                if (isCurrent)
-                {
-                    GUI.color = Color.green;
-                    Text.Anchor = TextAnchor.MiddleCenter;
-                    Widgets.Label(applyRect, "Active");
-                    GUI.color = Color.white;
-                    Text.Anchor = TextAnchor.UpperLeft;
-                }
-                else
-                {
-                    if (Widgets.ButtonText(applyRect, "Apply"))
-                    {
-                        settings.lastUsedShip = ship;
-                        WriteSettings();
-                        Messages.Message($"[GravshipExport] Ship '{ship.label}' set as default.", MessageTypeDefOf.PositiveEvent, false);
-                    }
-                }
-            }
-
-            Widgets.EndScrollView();
+                    exportController.DeleteShipFile(item.ExportFilename);
+                    ShipManager.Refresh();
+                }));
         }
 
-        private void TryDeleteShipFile(string filename)
+        private void HandleApplyRequest(ShipListItem item)
         {
-            try
-            {
-                string path = Path.Combine(GenFilePaths.ConfigFolderPath, "GravshipExport", filename);
-                if (File.Exists(path))
-                {
-                    File.Delete(path);
-                    Messages.Message($"[GravshipExport] Deleted ship: {filename}", MessageTypeDefOf.PositiveEvent, false);
-                }
-            }
-            catch (Exception ex)
-            {
-                Log.Error($"[GravshipExport] Failed to delete ship file {filename}: {ex}");
-                Messages.Message("[GravshipExport] Failed to delete ship file. See log.", MessageTypeDefOf.RejectInput, false);
-            }
+            if (item?.Ship == null)
+                return;
+
+            settings.lastUsedShip = item.Ship;
+            WriteSettings();
+            Messages.Message($"[GravshipExport] Ship '{item.Ship.label}' set as default.", MessageTypeDefOf.PositiveEvent, false);
         }
 
-        private List<ShipItem> BuildShipRows()
+        private void HandleExportRequest(ShipListItem item)
         {
-            var rows = new List<ShipItem>();
+            if (item?.Ship == null)
+                return;
 
-            // ✅ User-created (previously "Exported")
-            foreach (var kvp in ShipManager.LoadedShips)
-            {
-                rows.Add(new ShipItem
-                {
-                    Ship = kvp.Value,
-                    IsExported = true,
-                    ExportFilename = kvp.Key,
-                    SourceLabel = "User Created"
-                });
-            }
-
-            var exportedDefNames = new HashSet<string>(rows.Select(r => r.Ship?.defName).Where(d => !string.IsNullOrEmpty(d)));
-            var modDefs = DefDatabase<ShipLayoutDefV2>.AllDefsListForReading;
-
-            foreach (var ship in modDefs)
-            {
-                if (ship == null || string.IsNullOrEmpty(ship.defName)) continue;
-                if (exportedDefNames.Contains(ship.defName)) continue;
-
-                // ✅ Detect if this def belongs to *our own mod* (the built-in examples)
-                string source = "Built-in";
-                var pack = ship.modContentPack;
-                if (pack != null)
-                {
-                    if (pack.PackageId.Equals(Content.PackageId, StringComparison.OrdinalIgnoreCase))
-                        source = "Built-in Example";
-                    else
-                        source = $"Mod: {pack.Name}";
-                }
-
-                rows.Add(new ShipItem
-                {
-                    Ship = ship,
-                    IsExported = false,
-                    ExportFilename = null,
-                    SourceLabel = source
-                });
-            }
-
-            return rows.OrderBy(r => r.Ship?.label).ToList();
+            exportTarget = item;
+            exportNameBuffer = $"Gravship_{(item.Ship.label ?? item.Ship.defName ?? "NewShip")}";
+            exportPromptOpen = true;
         }
 
-        private string CurrentSelectionKey()
+        private void HandleExportCreation()
         {
-            if (settings.lastUsedShip == null)
-                return null;
+            if (exportTarget?.Ship == null)
+                return;
 
-            string defName = settings.lastUsedShip.defName;
+            if (string.IsNullOrWhiteSpace(exportNameBuffer))
+                return;
 
-            foreach (var kvp in ShipManager.LoadedShips)
-            {
-                if (ReferenceEquals(kvp.Value, settings.lastUsedShip))
-                    return kvp.Key;
-            }
-
-            foreach (var kvp in ShipManager.LoadedShips)
-            {
-                if (kvp.Value?.defName == defName)
-                    return kvp.Key;
-            }
-
-            return defName;
+            exportController.ExportShipAsMod(exportTarget.Ship, exportNameBuffer, CloseExportPrompt);
         }
 
-        private void TryExportShipAsMod(ShipItem item, string userModName)
+        private void CloseExportPrompt()
         {
-            if (item == null || item.Ship == null) return;
-
-            string modsRoot = GenFilePaths.ModsFolderPath;
-            string folderName = SanitizeFolderName(userModName);
-            string modFolder = Path.Combine(modsRoot, folderName);
-
-            if (Directory.Exists(modFolder))
-            {
-                Find.WindowStack.Add(Dialog_MessageBox.CreateConfirmation(
-                    $"A mod folder named '{folderName}' already exists.\n\nOverwrite the ship definition file?\n\n(About.xml will be preserved.)",
-                    () => DoExportShipAsMod(item.Ship, modFolder, userModName),
-                    true));
-            }
-            else
-            {
-                DoExportShipAsMod(item.Ship, modFolder, userModName);
-            }
+            exportPromptOpen = false;
+            exportTarget = null;
+            exportNameBuffer = string.Empty;
         }
 
-        private void DoExportShipAsMod(ShipLayoutDefV2 ship, string modFolder, string modName)
-        {
-            try
-            {
-                string aboutDir = Path.Combine(modFolder, "About");
-                string defsDir = Path.Combine(modFolder, "Defs", "ShipLayoutDefs");
-                Directory.CreateDirectory(aboutDir);
-                Directory.CreateDirectory(defsDir);
-
-                string author = "Unknown";
-                try
-                {
-                    author = SteamUtility.SteamPersonaName ?? "Unknown";
-                }
-                catch { }
-
-                string safeAuthor = SanitizeIdPart(author);
-                string safeModName = SanitizeIdPart(modName);
-                string packageId = $"{safeAuthor}.{safeModName}";
-
-                string aboutPath = Path.Combine(aboutDir, "About.xml");
-                if (!File.Exists(aboutPath))
-                {
-                    string aboutXml = BuildAboutXml(modName, author, packageId);
-                    File.WriteAllText(aboutPath, aboutXml);
-                }
-
-                string temp = Path.GetTempFileName();
-                DirectXmlSaver.SaveDataObject(ship, temp);
-                string raw = File.ReadAllText(temp);
-                File.Delete(temp);
-
-                string wrapped = WrapInDefs(raw);
-                string defFileName = $"{(string.IsNullOrEmpty(ship.defName) ? "ShipLayout" : ship.defName)}.xml";
-                string defPath = Path.Combine(defsDir, defFileName);
-                File.WriteAllText(defPath, wrapped);
-
-                Messages.Message($"[GravshipExport] Exported '{ship.label ?? ship.defName}' as mod:\n{modFolder}", MessageTypeDefOf.PositiveEvent, false);
-                if (DebugLogs) Log.Message($"[GravshipExport/Export] Wrote About.xml to {aboutPath} (created only if absent)");
-                if (DebugLogs) Log.Message($"[GravshipExport/Export] Wrote Def to {defPath}");
-            }
-            catch (Exception ex)
-            {
-                Log.Error($"[GravshipExport/Export] Failed to export mod: {ex}");
-                Messages.Message("[GravshipExport] Failed to export mod. See log.", MessageTypeDefOf.RejectInput, false);
-            }
-            finally
-            {
-                exportPromptOpen = false;
-                exportTarget = null;
-                exportNameBuffer = string.Empty;
-            }
-        }
-
-        private static string BuildAboutXml(string modName, string author, string packageId)
-        {
-            return
-$@"<?xml version=""1.0"" encoding=""utf-8""?>
-<ModMetaData>
-  <name>{SecurityElement.Escape(modName)}</name>
-  <author>{SecurityElement.Escape(author)}</author>
-  <packageId>{SecurityElement.Escape(packageId)}</packageId>
-  <supportedVersions>
-    <li>1.6</li>
-  </supportedVersions>
-  <description><![CDATA[Modifies the starting ship for the Gravship scenario. Exported using Gravship Export.]]></description>
-  <modDependencies>
-    <li>
-      <packageId>Arcjc007.GravshipExporter</packageId>
-      <displayName>Gravship Exporter</displayName>
-      <steamWorkshopUrl>steam://url/CommunityFilePage/3573188050</steamWorkshopUrl>
-      <downloadUrl>https://steamcommunity.com/sharedfiles/filedetails/?id=3573188050</downloadUrl>
-    </li>
-  </modDependencies>
-  <loadAfter>
-    <li>Arcjc007.GravshipExporter</li>
-  </loadAfter>
-</ModMetaData>";
-        }
-
-        private static string WrapInDefs(string inner)
-        {
-            string trimmed = inner.Trim();
-            if (trimmed.StartsWith("<?xml", StringComparison.Ordinal))
-            {
-                int idx = trimmed.IndexOf("?>", StringComparison.Ordinal);
-                if (idx >= 0) trimmed = trimmed.Substring(idx + 2).Trim();
-            }
-
-            trimmed = trimmed
-                .Replace("<ShipLayoutDefV2>", "<GravshipExport.ShipLayoutDefV2>")
-                .Replace("</ShipLayoutDefV2>", "</GravshipExport.ShipLayoutDefV2>");
-
-            return $"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Defs>\n{trimmed}\n</Defs>\n";
-        }
-
-        private static string SanitizeFolderName(string name)
-        {
-            if (string.IsNullOrWhiteSpace(name)) return "GravshipExport_Mod";
-            foreach (var c in Path.GetInvalidFileNameChars())
-                name = name.Replace(c, '_');
-            return name.Trim();
-        }
-
-        private static string SanitizeIdPart(string s)
-        {
-            if (string.IsNullOrEmpty(s)) return "User";
-            var chars = s.Where(ch => char.IsLetterOrDigit(ch) || ch == '.' || ch == '_').ToArray();
-            string cleaned = new string(chars);
-            if (string.IsNullOrEmpty(cleaned)) cleaned = "User";
-            if (!char.IsLetter(cleaned[0])) cleaned = "U" + cleaned;
-            return cleaned;
-        }
-
-        private static string GetShipInfo(ShipLayoutDefV2 ship)
-        {
-            if (ship == null) return "";
-            int width = ship.width;
-            int height = ship.height;
-
-            int thingCount = 0;
-            int terrainCells = 0;
-
-            if (ship.rows != null)
-            {
-                foreach (var row in ship.rows)
-                {
-                    if (row == null) continue;
-                    foreach (var cell in row)
-                    {
-                        if (cell == null) continue;
-                        if (cell.things != null) thingCount += cell.things.Count;
-                        if (!string.IsNullOrEmpty(cell.foundationDef) || !string.IsNullOrEmpty(cell.terrainDef))
-                            terrainCells++;
-                    }
-                }
-            }
-
-            return $"{width}×{height} | {thingCount} things | {terrainCells} terrain cells";
-        }
-
-        private static string HardCut(string text, int maxChars)
-        {
-            if (string.IsNullOrEmpty(text)) return text;
-            if (text.Length <= maxChars) return text;
-            return text.Substring(0, maxChars);
-        }
     }
 }

--- a/1.6/Source/GravshipExport/ModHeaderView.cs
+++ b/1.6/Source/GravshipExport/ModHeaderView.cs
@@ -1,0 +1,23 @@
+using UnityEngine;
+using Verse;
+
+namespace GravshipExport
+{
+    internal static class ModHeaderView
+    {
+        public static void Draw(Rect rect, ShipLayoutDefV2 currentShip, ref string searchText)
+        {
+            Widgets.DrawMenuSection(rect);
+            var inner = rect.ContractedBy(8f);
+
+            string currentLabel = currentShip != null ? currentShip.label : "None";
+            Widgets.Label(new Rect(inner.x, inner.y, inner.width, 24f), $"Current ship: {currentLabel}");
+
+            var searchLabelRect = new Rect(inner.x, inner.y + 32f, 100f, 24f);
+            Widgets.Label(searchLabelRect, "Search:");
+
+            var searchRect = new Rect(searchLabelRect.xMax + 8f, searchLabelRect.y, inner.width - searchLabelRect.width - 8f, 24f);
+            searchText = Widgets.TextField(searchRect, searchText);
+        }
+    }
+}

--- a/1.6/Source/GravshipExport/ShipExportController.cs
+++ b/1.6/Source/GravshipExport/ShipExportController.cs
@@ -1,0 +1,207 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Security;
+using RimWorld;
+using Verse;
+
+namespace GravshipExport
+{
+    internal sealed class ShipExportController
+    {
+        private readonly bool debugLogs;
+
+        public ShipExportController(ModContentPack content, bool debugLogs)
+        {
+            _ = content ?? throw new ArgumentNullException(nameof(content));
+            this.debugLogs = debugLogs;
+        }
+
+        public void DeleteShipFile(string filename)
+        {
+            try
+            {
+                string path = Path.Combine(GenFilePaths.ConfigFolderPath, "GravshipExport", filename);
+                if (File.Exists(path))
+                {
+                    File.Delete(path);
+                    Messages.Message($"[GravshipExport] Deleted ship: {filename}", MessageTypeDefOf.PositiveEvent, false);
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"[GravshipExport] Failed to delete ship file {filename}: {ex}");
+                Messages.Message("[GravshipExport] Failed to delete ship file. See log.", MessageTypeDefOf.RejectInput, false);
+            }
+        }
+
+        public void ExportShipAsMod(ShipLayoutDefV2 ship, string userModName, Action onComplete)
+        {
+            if (ship == null)
+            {
+                return;
+            }
+
+            string modsRoot = GenFilePaths.ModsFolderPath;
+            string folderName = SanitizeFolderName(userModName);
+            string modFolder = Path.Combine(modsRoot, folderName);
+
+            void PerformExport()
+            {
+                try
+                {
+                    DoExportShipAsMod(ship, modFolder, userModName);
+                }
+                finally
+                {
+                    onComplete?.Invoke();
+                }
+            }
+
+            if (Directory.Exists(modFolder))
+            {
+                Find.WindowStack.Add(Dialog_MessageBox.CreateConfirmation(
+                    $"A mod folder named '{folderName}' already exists.\n\nOverwrite the ship definition file?\n\n(About.xml will be preserved.)",
+                    PerformExport,
+                    true));
+            }
+            else
+            {
+                PerformExport();
+            }
+        }
+
+        private void DoExportShipAsMod(ShipLayoutDefV2 ship, string modFolder, string modName)
+        {
+            try
+            {
+                string aboutDir = Path.Combine(modFolder, "About");
+                string defsDir = Path.Combine(modFolder, "Defs", "ShipLayoutDefs");
+                Directory.CreateDirectory(aboutDir);
+                Directory.CreateDirectory(defsDir);
+
+                string author = "Unknown";
+                try
+                {
+                    author = SteamUtility.SteamPersonaName ?? "Unknown";
+                }
+                catch
+                {
+                    // ignored
+                }
+
+                string safeAuthor = SanitizeIdPart(author);
+                string safeModName = SanitizeIdPart(modName);
+                string packageId = $"{safeAuthor}.{safeModName}";
+
+                string aboutPath = Path.Combine(aboutDir, "About.xml");
+                if (!File.Exists(aboutPath))
+                {
+                    string aboutXml = BuildAboutXml(modName, author, packageId);
+                    File.WriteAllText(aboutPath, aboutXml);
+                }
+
+                string temp = Path.GetTempFileName();
+                DirectXmlSaver.SaveDataObject(ship, temp);
+                string raw = File.ReadAllText(temp);
+                File.Delete(temp);
+
+                string wrapped = WrapInDefs(raw);
+                string defFileName = $"{(string.IsNullOrEmpty(ship.defName) ? "ShipLayout" : ship.defName)}.xml";
+                string defPath = Path.Combine(defsDir, defFileName);
+                File.WriteAllText(defPath, wrapped);
+
+                Messages.Message($"[GravshipExport] Exported '{ship.label ?? ship.defName}' as mod:\n{modFolder}", MessageTypeDefOf.PositiveEvent, false);
+                if (debugLogs) Log.Message($"[GravshipExport/Export] Wrote About.xml to {aboutPath} (created only if absent)");
+                if (debugLogs) Log.Message($"[GravshipExport/Export] Wrote Def to {defPath}");
+            }
+            catch (Exception ex)
+            {
+                Log.Error($"[GravshipExport/Export] Failed to export mod: {ex}");
+                Messages.Message("[GravshipExport] Failed to export mod. See log.", MessageTypeDefOf.RejectInput, false);
+            }
+        }
+
+        private static string BuildAboutXml(string modName, string author, string packageId)
+        {
+            return
+@$"<?xml version=\"1.0\" encoding=\"utf-8\"?>
+<ModMetaData>
+  <name>{SecurityElement.Escape(modName)}</name>
+  <author>{SecurityElement.Escape(author)}</author>
+  <packageId>{SecurityElement.Escape(packageId)}</packageId>
+  <supportedVersions>
+    <li>1.6</li>
+  </supportedVersions>
+  <description><![CDATA[Modifies the starting ship for the Gravship scenario. Exported using Gravship Export.]]></description>
+  <modDependencies>
+    <li>
+      <packageId>Arcjc007.GravshipExporter</packageId>
+      <displayName>Gravship Exporter</displayName>
+      <steamWorkshopUrl>steam://url/CommunityFilePage/3573188050</steamWorkshopUrl>
+      <downloadUrl>https://steamcommunity.com/sharedfiles/filedetails/?id=3573188050</downloadUrl>
+    </li>
+  </modDependencies>
+  <loadAfter>
+    <li>Arcjc007.GravshipExporter</li>
+  </loadAfter>
+</ModMetaData>";
+        }
+
+        private static string WrapInDefs(string inner)
+        {
+            string trimmed = inner.Trim();
+            if (trimmed.StartsWith("<?xml", StringComparison.Ordinal))
+            {
+                int idx = trimmed.IndexOf("?>", StringComparison.Ordinal);
+                if (idx >= 0)
+                {
+                    trimmed = trimmed.Substring(idx + 2).Trim();
+                }
+            }
+
+            trimmed = trimmed
+                .Replace("<ShipLayoutDefV2>", "<GravshipExport.ShipLayoutDefV2>")
+                .Replace("</ShipLayoutDefV2>", "</GravshipExport.ShipLayoutDefV2>");
+
+            return $"<?xml version=\"1.0\" encoding=\"utf-8\"?>\n<Defs>\n{trimmed}\n</Defs>\n";
+        }
+
+        private static string SanitizeFolderName(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                return "GravshipExport_Mod";
+            }
+
+            foreach (var c in Path.GetInvalidFileNameChars())
+            {
+                name = name.Replace(c, '_');
+            }
+
+            return name.Trim();
+        }
+
+        private static string SanitizeIdPart(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                return "User";
+            }
+
+            var chars = value.Where(ch => char.IsLetterOrDigit(ch) || ch == '.' || ch == '_').ToArray();
+            string cleaned = new string(chars);
+            if (string.IsNullOrEmpty(cleaned))
+            {
+                cleaned = "User";
+            }
+
+            if (!char.IsLetter(cleaned[0]))
+            {
+                cleaned = "U" + cleaned;
+            }
+
+            return cleaned;
+        }
+    }
+}

--- a/1.6/Source/GravshipExport/ShipInfoFormatter.cs
+++ b/1.6/Source/GravshipExport/ShipInfoFormatter.cs
@@ -1,0 +1,62 @@
+using System.Text;
+using Verse;
+
+namespace GravshipExport
+{
+    internal static class ShipInfoFormatter
+    {
+        public static string GetInfo(ShipLayoutDefV2 ship)
+        {
+            if (ship == null)
+            {
+                return string.Empty;
+            }
+
+            int width = ship.width;
+            int height = ship.height;
+
+            int thingCount = 0;
+            int terrainCells = 0;
+
+            if (ship.rows != null)
+            {
+                foreach (var row in ship.rows)
+                {
+                    if (row == null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var cell in row)
+                    {
+                        if (cell == null)
+                        {
+                            continue;
+                        }
+
+                        if (cell.things != null)
+                        {
+                            thingCount += cell.things.Count;
+                        }
+
+                        if (!string.IsNullOrEmpty(cell.foundationDef) || !string.IsNullOrEmpty(cell.terrainDef))
+                        {
+                            terrainCells++;
+                        }
+                    }
+                }
+            }
+
+            var builder = new StringBuilder();
+            builder.Append(width);
+            builder.Append('×');
+            builder.Append(height);
+            builder.Append(" | ");
+            builder.Append(thingCount);
+            builder.Append(" things | ");
+            builder.Append(terrainCells);
+            builder.Append(" terrain cells");
+            return builder.ToString();
+        }
+    }
+}

--- a/1.6/Source/GravshipExport/ShipListBuilder.cs
+++ b/1.6/Source/GravshipExport/ShipListBuilder.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Verse;
+
+namespace GravshipExport
+{
+    internal static class ShipListBuilder
+    {
+        public static List<ShipListItem> Build(ModContentPack content)
+        {
+            var rows = new List<ShipListItem>();
+
+            foreach (var kvp in ShipManager.LoadedShips)
+            {
+                rows.Add(new ShipListItem
+                {
+                    Ship = kvp.Value,
+                    IsExported = true,
+                    ExportFilename = kvp.Key,
+                    SourceLabel = "User Created"
+                });
+            }
+
+            var exportedDefNames = new HashSet<string>(rows
+                .Select(r => r.Ship?.defName)
+                .Where(d => !string.IsNullOrEmpty(d)));
+
+            var modDefs = DefDatabase<ShipLayoutDefV2>.AllDefsListForReading;
+            foreach (var ship in modDefs)
+            {
+                if (ship == null || string.IsNullOrEmpty(ship.defName))
+                {
+                    continue;
+                }
+
+                if (exportedDefNames.Contains(ship.defName))
+                {
+                    continue;
+                }
+
+                string source = "Built-in";
+                var pack = ship.modContentPack;
+                if (pack != null)
+                {
+                    if (pack.PackageId.Equals(content.PackageId, StringComparison.OrdinalIgnoreCase))
+                    {
+                        source = "Built-in Example";
+                    }
+                    else
+                    {
+                        source = $"Mod: {pack.Name}";
+                    }
+                }
+
+                rows.Add(new ShipListItem
+                {
+                    Ship = ship,
+                    IsExported = false,
+                    ExportFilename = null,
+                    SourceLabel = source
+                });
+            }
+
+            return rows
+                .OrderBy(r => r.Ship?.label)
+                .ToList();
+        }
+    }
+}

--- a/1.6/Source/GravshipExport/ShipListCallbacks.cs
+++ b/1.6/Source/GravshipExport/ShipListCallbacks.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace GravshipExport
+{
+    internal sealed class ShipListCallbacks
+    {
+        public Action<ShipListItem> DeleteRequested { get; set; }
+        public Action<ShipListItem> ApplyRequested { get; set; }
+        public Action<ShipListItem> ExportRequested { get; set; }
+    }
+}

--- a/1.6/Source/GravshipExport/ShipListItem.cs
+++ b/1.6/Source/GravshipExport/ShipListItem.cs
@@ -1,0 +1,12 @@
+using Verse;
+
+namespace GravshipExport
+{
+    internal sealed class ShipListItem
+    {
+        public ShipLayoutDefV2 Ship { get; set; }
+        public bool IsExported { get; set; }
+        public string ExportFilename { get; set; }
+        public string SourceLabel { get; set; }
+    }
+}

--- a/1.6/Source/GravshipExport/ShipListView.cs
+++ b/1.6/Source/GravshipExport/ShipListView.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Verse;
+
+namespace GravshipExport
+{
+    internal sealed class ShipListView
+    {
+        private readonly Func<List<ShipListItem>> rowsProvider;
+        private readonly ShipRowDrawer rowDrawer;
+        private Vector2 scrollPosition;
+
+        public ShipListView(Func<List<ShipListItem>> rowsProvider, ShipRowDrawer rowDrawer)
+        {
+            this.rowsProvider = rowsProvider;
+            this.rowDrawer = rowDrawer;
+        }
+
+        public void Draw(Rect outRect, string searchText, string currentSelectionKey, ShipListCallbacks callbacks)
+        {
+            var rows = rowsProvider?.Invoke() ?? new List<ShipListItem>();
+            if (rows.Count == 0)
+            {
+                Widgets.Label(outRect, "No ships found.\n\n• Export a ship in-game\n• Load a mod with ShipLayoutDefV2.");
+                return;
+            }
+
+            string filter = string.IsNullOrWhiteSpace(searchText) ? null : searchText.ToLowerInvariant();
+            if (!string.IsNullOrEmpty(filter))
+            {
+                rows = rows
+                    .Where(r => MatchesFilter(r, filter))
+                    .ToList();
+
+                if (rows.Count == 0)
+                {
+                    Widgets.Label(outRect, "No ships match your search.");
+                    return;
+                }
+            }
+
+            float viewHeight = rows.Count * ShipRowDrawer.RowHeight;
+            var viewRect = new Rect(0f, 0f, outRect.width - 16f, viewHeight);
+            Widgets.BeginScrollView(outRect, ref scrollPosition, viewRect);
+
+            for (int i = 0; i < rows.Count; i++)
+            {
+                var item = rows[i];
+                var rowRect = new Rect(0f, i * ShipRowDrawer.RowHeight, viewRect.width, ShipRowDrawer.RowHeight);
+
+                string rowKey = item.IsExported ? item.ExportFilename : item.Ship?.defName;
+                bool isCurrent = !string.IsNullOrEmpty(currentSelectionKey) &&
+                                 !string.IsNullOrEmpty(rowKey) &&
+                                 currentSelectionKey.Equals(rowKey, StringComparison.OrdinalIgnoreCase);
+
+                var result = rowDrawer.DrawRow(rowRect, item, isCurrent, i % 2 == 1);
+                if (result.DeleteRequested)
+                {
+                    callbacks?.DeleteRequested?.Invoke(item);
+                }
+
+                if (result.ApplyRequested)
+                {
+                    callbacks?.ApplyRequested?.Invoke(item);
+                }
+
+                if (result.ExportRequested)
+                {
+                    callbacks?.ExportRequested?.Invoke(item);
+                }
+            }
+
+            Widgets.EndScrollView();
+        }
+
+        private static bool MatchesFilter(ShipListItem item, string filter)
+        {
+            string label = item.Ship?.label?.ToLowerInvariant();
+            if (!string.IsNullOrEmpty(label) && label.Contains(filter))
+            {
+                return true;
+            }
+
+            string defName = item.Ship?.defName?.ToLowerInvariant();
+            if (!string.IsNullOrEmpty(defName) && defName.Contains(filter))
+            {
+                return true;
+            }
+
+            if (item.IsExported)
+            {
+                string filename = item.ExportFilename?.ToLowerInvariant();
+                if (!string.IsNullOrEmpty(filename) && filename.Contains(filter))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/1.6/Source/GravshipExport/ShipRowDrawer.cs
+++ b/1.6/Source/GravshipExport/ShipRowDrawer.cs
@@ -1,0 +1,137 @@
+using System;
+using UnityEngine;
+using Verse;
+using RimWorld;
+
+namespace GravshipExport
+{
+    internal sealed class ShipRowDrawer
+    {
+        private const float RowPad = 4f;
+        private const float DeleteButtonWidth = 32f;
+        private const float ApplyButtonWidth = 50f;
+        private const float ExportButtonWidth = 50f;
+        private const float InfoWidth = 300f;
+        private const float SourceWidth = 200f;
+
+        private const int LabelMaxChars = 30;
+        private const int SourceMaxChars = 30;
+        private const int InfoMaxChars = 40;
+
+        public const float RowHeight = 42f;
+
+        public ShipRowResult DrawRow(Rect rowRect, ShipListItem item, bool isCurrent, bool isAlternateRow)
+        {
+            if (isCurrent)
+            {
+                Widgets.DrawBoxSolid(rowRect, new Color(0f, 1f, 0f, 0.15f));
+            }
+            else if (isAlternateRow)
+            {
+                Widgets.DrawBoxSolid(rowRect, new Color(1f, 1f, 1f, 0.05f));
+            }
+
+            var result = new ShipRowResult();
+            float curX = rowRect.x + RowPad;
+
+            if (item.IsExported)
+            {
+                var deleteRect = new Rect(curX, rowRect.y + RowPad, DeleteButtonWidth, RowHeight - 2 * RowPad);
+                if (Widgets.ButtonImage(deleteRect, TexButton.Delete))
+                {
+                    result.DeleteRequested = true;
+                }
+            }
+
+            curX += DeleteButtonWidth + RowPad;
+
+            float rightX = rowRect.xMax - RowPad;
+
+            var applyRect = new Rect(rightX - ApplyButtonWidth, rowRect.y + RowPad, ApplyButtonWidth, RowHeight - 2 * RowPad);
+            rightX -= ApplyButtonWidth + RowPad;
+
+            var exportRect = new Rect(rightX - ExportButtonWidth, rowRect.y + RowPad, ExportButtonWidth, RowHeight - 2 * RowPad);
+            rightX -= ExportButtonWidth + RowPad;
+
+            var infoRect = new Rect(rightX - InfoWidth, rowRect.y + RowPad, InfoWidth, RowHeight - 2 * RowPad);
+            rightX -= InfoWidth + RowPad;
+
+            var sourceRect = new Rect(rightX - SourceWidth, rowRect.y + RowPad, SourceWidth, RowHeight - 2 * RowPad);
+            rightX -= SourceWidth + RowPad;
+
+            var labelRect = new Rect(curX, rowRect.y + RowPad, rightX - curX, RowHeight - 2 * RowPad);
+
+            DrawLabel(item, labelRect);
+            DrawSource(item, sourceRect);
+            DrawInfo(item, infoRect);
+
+            if (item.IsExported)
+            {
+                if (Widgets.ButtonText(exportRect, "Export"))
+                {
+                    result.ExportRequested = true;
+                }
+            }
+
+            if (isCurrent)
+            {
+                GUI.color = Color.green;
+                Text.Anchor = TextAnchor.MiddleCenter;
+                Widgets.Label(applyRect, "Active");
+                GUI.color = Color.white;
+                Text.Anchor = TextAnchor.UpperLeft;
+            }
+            else
+            {
+                if (Widgets.ButtonText(applyRect, "Apply"))
+                {
+                    result.ApplyRequested = true;
+                }
+            }
+
+            return result;
+        }
+
+        private static void DrawLabel(ShipListItem item, Rect rect)
+        {
+            string fullLabel = item.Ship?.label ?? item.Ship?.defName ?? "Unnamed Ship";
+            string drawLabel = StringUtilities.HardCut(fullLabel, LabelMaxChars);
+            Widgets.Label(rect, drawLabel);
+            if (!string.Equals(fullLabel, drawLabel, StringComparison.Ordinal))
+            {
+                TooltipHandler.TipRegion(rect, fullLabel);
+            }
+        }
+
+        private static void DrawSource(ShipListItem item, Rect rect)
+        {
+            string fullSource = item.SourceLabel ?? string.Empty;
+            string drawSource = StringUtilities.HardCut(fullSource, SourceMaxChars);
+            GUI.color = new Color(0.7f, 0.7f, 0.7f, 1f);
+            Widgets.Label(rect, drawSource);
+            GUI.color = Color.white;
+            if (!string.Equals(fullSource, drawSource, StringComparison.Ordinal))
+            {
+                TooltipHandler.TipRegion(rect, fullSource);
+            }
+        }
+
+        private static void DrawInfo(ShipListItem item, Rect rect)
+        {
+            string fullInfo = ShipInfoFormatter.GetInfo(item.Ship);
+            string drawInfo = StringUtilities.HardCut(fullInfo, InfoMaxChars);
+            Widgets.Label(rect, drawInfo);
+            if (!string.Equals(fullInfo, drawInfo, StringComparison.Ordinal))
+            {
+                TooltipHandler.TipRegion(rect, fullInfo);
+            }
+        }
+    }
+
+    internal struct ShipRowResult
+    {
+        public bool DeleteRequested { get; set; }
+        public bool ApplyRequested { get; set; }
+        public bool ExportRequested { get; set; }
+    }
+}

--- a/1.6/Source/GravshipExport/ShipSelectionHelper.cs
+++ b/1.6/Source/GravshipExport/ShipSelectionHelper.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using Verse;
+
+namespace GravshipExport
+{
+    internal static class ShipSelectionHelper
+    {
+        public static string GetCurrentSelectionKey(GravshipExportModSettings settings, Dictionary<string, ShipLayoutDefV2> loadedShips)
+        {
+            if (settings?.lastUsedShip == null)
+            {
+                return null;
+            }
+
+            string defName = settings.lastUsedShip.defName;
+            if (loadedShips != null)
+            {
+                foreach (var kvp in loadedShips)
+                {
+                    if (ReferenceEquals(kvp.Value, settings.lastUsedShip))
+                    {
+                        return kvp.Key;
+                    }
+                }
+
+                foreach (var kvp in loadedShips)
+                {
+                    if (kvp.Value?.defName == defName)
+                    {
+                        return kvp.Key;
+                    }
+                }
+            }
+
+            return defName;
+        }
+    }
+}

--- a/1.6/Source/GravshipExport/StringUtilities.cs
+++ b/1.6/Source/GravshipExport/StringUtilities.cs
@@ -1,0 +1,20 @@
+namespace GravshipExport
+{
+    internal static class StringUtilities
+    {
+        public static string HardCut(string text, int maxChars)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return text;
+            }
+
+            if (text.Length <= maxChars)
+            {
+                return text;
+            }
+
+            return text.Substring(0, maxChars);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- refactor `GravshipExportMod` to coordinate modular UI components for the header, export prompt, and ship list
- introduce dedicated classes to build ship data, render list rows, and format ship information for clearer responsibilities
- encapsulate export and deletion logic within `ShipExportController` to centralize file interactions

## Testing
- dotnet build 1.6/Source/GravshipExport.csproj *(fails: `dotnet`: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e969a53883208d29d68325de65ec